### PR TITLE
Tweak the docs

### DIFF
--- a/content/docs/deploying.md
+++ b/content/docs/deploying.md
@@ -7,7 +7,7 @@ next: '/docs/settings/'
 
 # Deploying
 
-Gridsome generates static files when running the `gridsome build` command. By default it outputs to the `dist` directory.
-Since these are simple HTML and JS files you only need a server which hosts these files.
+Gridsome generates static files when the `gridsome build` command runs. By default it generates output in the `dist` directory.
+Since these are simple HTML and JS files, you only need a server which hosts these files.
 
-If you need more information on this topic, check out the [Gridsome Docs](https://gridsome.org/docs/deploy-to-netlify/) on this issue.
+For more information on deploying, check out the [Gridsome Docs](https://gridsome.org/docs/deploy-to-netlify/).

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -6,29 +6,29 @@ next: '/docs/installation/'
 
 # Introduction
 
-Docc is a starter theme for [Gridsome](https://gridsome.org/) which is a static site generator powered by Vue. It allows you to quickly start writing your technical documentation for any kind of project.
+Docc is a starter theme for [Gridsome](https://gridsome.org/), which is a static site generator powered by Vue. It allows you to quickly start writing your technical documentation for any kind of project.
 
 ## Fast by default
 
-This is the catchphrase of Gridsome and true in any sense of the word. Static site generators output plain html files and have other great features like image processing and lazy-loading. After Serving the initial html, Gridsome site turn into a snappy single page application.
+This is the catchphrase of Gridsome and true in any sense of the word. Static site generators output plain HTML files and have other great features like image processing and lazy-loading. After serving the initial HTML, a Gridsome site turns into a snappy single-page application.
 
 If I may quote Gridsome themselves:
 
 > Gridsome builds ultra performance into every page automatically. You get code splitting, asset optimization, progressive images, and link prefetching out of the box. With Gridsome you get almost perfect page speed scores by default.
 
-In combination with [Netlify](https://www.netlify.com/) this theme gives you a perfect Lighthouse score out of the box.
+In combination with [Netlify](https://www.netlify.com/), this theme gives you a perfect Lighthouse score out of the box.
 
 ## Simple Navigation
 
-Any good documentation has great navigation. This theme has support for an organized sidebar for cross-page navigation as well as an autmatic generated table of contents for each page in your documentation.
+Any good documentation has great navigation. This theme has support for an organized sidebar for cross-page navigation as well as an automatic generated table of contents for each page in your documentation.
 
 ## Search
 
-The search component which is shipped with this theme, automatically indexes all headlines in your markdown pages and provides instant, client-side search powered by [Fuse.js](https://fusejs.io/).
+The search component that is shipped with this theme automatically indexes all headlines in your Markdown pages and provides instant, client-side search powered by [Fuse.js](https://fusejs.io/).
 
 ## Dark Mode
 
-This seems to be a must have for any site in current year. Click the icon at the top of the page and try it out for yourself!
+This seems to be a must have for any site this year. Click the icon at the top of the page and try it out for yourself!
 
 ## TailwindCSS
 

--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -19,7 +19,7 @@ If you don't already have it installed, simply run:
 npm i -g @gridsome/cli
 ```
 
-After that run `gridsome -v` to verify that the tool is working.
+After that, run `gridsome -v` to verify that the tool is working.
 
 If everything is working as expected, run the following command:
 
@@ -29,7 +29,7 @@ gridsome create your-project-name https://github.com/mrcrmn/docc
 
 This command creates a folder named `your-project-name` in your current working directory, clones the repository and automatically installs the dependencies.
 
-If everything is downloaded and installed you can now run `npm run develop` which starts the development server and bundles all assets. After bootstrapping has finished, head to `http://localhost:8080` to view your freshly created site!
+Once everything is downloaded and installed, you can run `npm run develop` to start the development server and bundle all assets. After bootstrapping has finished, head to `http://localhost:8080` to view your freshly created site!
 
 ## Installing manually
 
@@ -38,13 +38,13 @@ To install this theme manually you need to:
 1. Clone the repository
 2. Install the dependencies
 
-To clone the repository simply run:
+To clone the repository, run:
 
 ```bash
 git clone https://github.com/mrcrmn/docc.git
 ```
 
-After cloning the project, change to the project you just created.
+After cloning the project, change to the directory you just created.
 
 ```bash
 cd docc
@@ -52,14 +52,14 @@ cd docc
 
 Now you only need to install the dependencies.
 
-Using npm:
+Using `npm`:
 ```bash
 npm install
 ```
 
-Or by using yarn:
+Or using `yarn`:
 ```bash
 yarn
 ```
 
-After all dependencies are installed you can now run `npm run develop` to start the development server!
+After all dependencies are installed, you can run `npm run develop` to start the development server!

--- a/content/docs/settings.md
+++ b/content/docs/settings.md
@@ -7,7 +7,7 @@ next: '/docs/sidebar/'
 
 # Settings
 
-When creating your markdown files, there is some configuration to do, if we want to utilise all features of this starter theme.
+Using all features of this starter theme requires a bit of configuration.
 
 ## Sidebar
 
@@ -16,18 +16,18 @@ Check out the [sidebar](/docs/sidebar/) section for more information.
 
 ## Next and Previous Navigation
 
-If you scroll to the bottom of the page, you will notice some buttons which link to the previous pages in these docs. These are also not automatically generated but configured in the frontmatter of your markdown file like this:
+If you scroll to the bottom of the page, you will notice some buttons that link to other pages in these docs. These are also not automatically generated, but configured in the frontmatter of your Markdown file like this:
 
 ```md
 prev: '/docs/previous-link/'
 next: '/docs/next-link/'
 ```
 
-Just like the sidebar, you only need to specify the link to the page and the title will be fetched via a graphql query.
+Just like the sidebar, you only need to specify the link to the page and the title will be fetched via a GraphQL query.
 
 ## Navigation
 
-The standard navigation on the top left is defined in the `gridsome.config.js` file. The configuration is very simple. It just needs a `settings > nav` property which takes a `links` property that defines every link that should be displayed at the top.
+The standard navigation on the top left is defined in the `gridsome.config.js` file. The configuration is very simple. It just needs a `settings > nav` property, which takes a `links` property that defines each link that should be displayed at the top.
 
 ```js
 module.exports = {
@@ -45,7 +45,7 @@ Each link item needs a `path` and a `title` for the link.
 
 ## Description
 
-The description of each page goes to the frontmatter of said page. It is an optional value but is recommended since this value is used to fill some meta properties of your page.
+Description metadata can be defined in the frontmatter of each page. It is optional but recommended, since this value is used for link previews and on search results pages.
 
 ```md
 ---
@@ -55,7 +55,7 @@ description: 'your description'
 
 ## Social Links
 
-At the top of the page, you can see some icons which link to Twitter/GitHub or personal website. These links are also defined in your `gridsome.config.js` like this:
+At the top of the page, you can see a few icons that link to another website, Twitter, or GitHub profile. These links are also defined in the `gridsome.config.js` file like this:
 
 ```js
 
@@ -67,19 +67,19 @@ module.exports = {
   }
 ```
 
-By default these are defined in your `.env` file but can be hardcoded if you want to.
+These are read from your `.env` file by default, but can be hardcoded in the `gridsome.config.js` file if you prefer.
 
 ## On this Page
 
-On the right side of the page is an overview of every headline of the current viewed page. Fortunately this list is auto-generated and you don't need to do anything.
+The right sidebar contains a table of contents that shows the headings on the current page. Fortunately, this list is auto-generated and you don't need to do anything.
 
 ## Google Analytics
 
-Google Analytics is integrated via the `@gridsome/plugin-google-analytics` plugin. It needs your tracking id in order to work correctly, which can also be defined via `.env` file or hardcoded as needed.
+Google Analytics is integrated via the `@gridsome/plugin-google-analytics` plugin. It needs your tracking ID to work correctly. You can define this in your `.env` file or hardcode it in the `gridsome.config.js` file if you prefer.
 
 If you don't want to use Google Analytics, simply delete this entry from your `plugins`.
 
-Read more [here](https://gridsome.org/plugins/@gridsome/plugin-google-analytics).
+For more information on the analytics plugin, see the [Gridsome Docs](https://gridsome.org/plugins/@gridsome/plugin-google-analytics).
 
 ```js
 // ...

--- a/content/docs/sidebar.md
+++ b/content/docs/sidebar.md
@@ -6,10 +6,11 @@ prev: '/docs/settings/'
 
 # Sidebar
 
-In order to have a sidebar visible on the side of the page (like on this one for example) or on mobile devices as an off-canvas navigation, you are required to do some global configuration, as well as some configuration per markdown file.
+To include a navigation sidebar on the left (like on this page, for example) or on mobile devices as an off-canvas navigation, adjust the settings in the global configuration, and add a reference to the sidebar in the frontmatter of each Markdown file.
 
 ## Global Configuration
-Open the `gridsome.config.js`. The configuration for the sidebar is located under `settings > sidebar`.
+
+Open the `gridsome.config.js` file. The configuration for the sidebar is located under `settings > sidebar`.
 
 ```js
 // gridsome.config.js
@@ -22,13 +23,13 @@ module.exports = {
 }
 ```
 
-Please note that the sidebar option is an array, since you can define multiple sidebars for different sections of your website. For example you might have a sidebar for your guide and another one for your API reference.
+Please note that the sidebar option is an array, so you can define multiple sidebars for different sections of your website. For example, you might have a sidebar for your user guide and another one for your API reference.
 
 ### The Sidebar Config Object
 
-A single item in this array needs to have the following properties:
-- `name`: The identifier of the sidebar. This will be referenced in your markdown frontmatter.
-- `sections`: The sidebar is divided into several sections. On this page we have **Getting Started** and **Configuration**
+Each sidebar in this array requires the following properties:
+- `name`: The identifier of the sidebar. This will be referenced in your Markdown frontmatter.
+- `sections`: The sidebar is divided into several sections. On this page, we have **Getting Started** and **Configuration**.
 
 ```js
 // gridsome.config.js
@@ -44,7 +45,7 @@ module.exports = {
 }
 ```
 
-An item for the `sections` array might look like this:
+A sample `sections` array might look like this:
 
 ```js
 // gridsome.config.js
@@ -69,15 +70,15 @@ module.exports = {
 }
 ```
 
-As you can see, we need a `title` for the sections, as well as an array of `items` which are the links to the given pages.
+As you can see, we need a `title` for each section, and an array of `items`, which are the links to the pages in the section.
 
 The sidebar performs a static query to get all pages. This is how we automatically put the title of the given page in the sidebar.
 
 ## Frontmatter setup
 
-After your global configuration is all done, we only need to tell the markdown page which sidebar to use.
+After your global configuration is all done, we only need to tell the Markdown page which sidebar to use.
 
-In order to do that we simply reference the `name` of the sidebar in our frontmatter:
+To do that, we simply reference the `name` of the sidebar in our frontmatter:
 
 ```md
 ---

--- a/content/docs/writing-content.md
+++ b/content/docs/writing-content.md
@@ -2,7 +2,7 @@
 description: ''
 sidebar: 'docs'
 prev: '/docs/installation/'
-next: '/docs/settings/'
+next: '/docs/deploying/'
 ---
 
 # Writing Content

--- a/content/docs/writing-content.md
+++ b/content/docs/writing-content.md
@@ -8,7 +8,7 @@ next: '/docs/settings/'
 # Writing Content
 
 After installing, head to `content/docs`. This is where all the documentation for this theme is located.
-You can look into it if you want, to get a sense of how this theme works but generally the first action you take, is to delete that folder and create your own content.
+You can look inside to get a sense of how this theme works, but you’ll probably want to delete the contents of that folder and create your own content.
 
 ## Writing Markdown
 
@@ -36,4 +36,4 @@ plugins: [
 ]
 ```
 
-If you have never worked with markdown, just search the internet for a guide. It is very simple to pick up.
+If you have never worked with Markdown, just search the internet for a guide. It is very simple to pick up.


### PR DESCRIPTION
🙏 Thanks for this theme, looks like it ticks all the boxes for a lightweight and modern docs site.

I'm considering using this for a client project, but before I build on your work I figured I should make a contribution, so I'm proposing a few minor changes to the docs here.

- 8001e05 includes some basic copy editing in each topic, including:
  - Fix capitalization of several terms (GraphQL, HTML, Markdown, etc.)
  - Correct a few commas, that/which, etc.
  - Simplify sentence structure
  - Clarify docs link targets
- 859ae66 fixes the `next` link on the **Writing Content** page to align the browse sequence with the intention implied by the `prev` link on the **Deploying** page.

— _Thanks for your work, hope this helps…_

P.S. I based this on your `develop` branch, as I found a few related changes there that haven't landed on `master` yet. 