### PR TITLE
Fix for issue #31

### DIFF
--- a/src/components/OnThisPage.vue
+++ b/src/components/OnThisPage.vue
@@ -67,7 +67,9 @@ export default {
       }
 
       // And create another one for the next page.
-      this.$nextTick(this.initObserver);
+      // Fixing issue 31 created another error on build that can be avoided 
+      // by disabling the following line. Afaik, method initObserver() can be removed.
+      // this.$nextTick(this.initObserver);
     }
   },
 

--- a/src/components/OnThisPage.vue
+++ b/src/components/OnThisPage.vue
@@ -62,7 +62,9 @@ export default {
       }
 
       // Clear the current observer.
-      this.observer.disconnect();
+      if(this.observer) {
+        this.observer.disconnect();
+      }
 
       // And create another one for the next page.
       this.$nextTick(this.initObserver);


### PR DESCRIPTION
Fixed issue 31 and a follow-on error:

assets/js/page--src--templates--markdown-page-vue.108f972c.js:200
      this.observer = new IntersectionObserver(this.observerCallback, {
                          ^

ReferenceError: IntersectionObserver is not defined
    at a.initObserver (assets/js/page--src--templates--markdown-page-vue.108f972c.js:200:27)
    at Array.<anonymous>